### PR TITLE
Update includes and fix Chrome issue

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -131,10 +131,7 @@
 	  	  <include name="webmaths.jar"/>
 	  	</fileset>
 	  	<fileset dir="${jaxws.home}/lib">
-		    <include name="jaxws-rt.jar"/>
-		    <include name="streambuffer.jar"/>
-		    <include name="stax-ex.jar"/>
-		    <include name="jaxb-impl.jar"/>
+		    <include name="*.jar"/>
 	  	</fileset>
 		</copy>
 		<copy todir="${build}/WEB-INF">

--- a/misc/ou-mathjax-batchprocessor
+++ b/misc/ou-mathjax-batchprocessor
@@ -13,7 +13,8 @@ var equationfont = process.argv[3];
 mj.config({
   MathJax: {
     SVG: {
-      font: equationfont
+      font: equationfont,
+      blacker: 10
     },
     menuSettings: {
       semantics: true

--- a/src/uk/ac/open/lts/webmaths/mathjax/MathJax.java
+++ b/src/uk/ac/open/lts/webmaths/mathjax/MathJax.java
@@ -638,11 +638,11 @@ public class MathJax
 	 * Makes an SVG thinner by removing the stroke width.
 	 *
 	 * @param svg SVG input
-	 * @return SVG without any stroke-width 1s
+	 * @return SVG without any stroke-width 10s
 	 */
 	private static String makeThin(String svg)
 	{
-		return svg.replaceAll("stroke-width=\"1\"", "");
+		return svg.replaceAll("stroke-width=\"10\"", "");
 	}
 
 	/**


### PR DESCRIPTION
The first commit adds *.jar to the jaxws includes because each time we added a jar it complained another one was missing.

The second commit just reverts part of the code that was changed when switching to mathjax-node-sre which changed the width of the lines from 10 to 1. This was causing an issue in Chrome where parts of plus signs were invisible.