### PR TITLE
SVG margin reset

### DIFF
--- a/src/uk/ac/open/lts/webmaths/mathjax/MathJax.java
+++ b/src/uk/ac/open/lts/webmaths/mathjax/MathJax.java
@@ -364,6 +364,9 @@ public class MathJax
 				String style = root.getAttribute("style");
 				style = style.replaceFirst("vertical-align: -?[0-9.]+",
 					"vertical-align: " + round(-baselineEx));
+
+				// Reset margin to 0.
+				style = style.concat("margin: 0px");
 				root.setAttribute("style", style);
 
 				// Remember the precise figures for next calculation.


### PR DESCRIPTION
SVG images rendered using math_node_sre has margin-bottom which is causing style issues. 
This commit resets the margin as mathjax_node does for all equation svgs.