### PR TITLE
MathJax: Webmaths empty equation error:#410147

### DIFF
--- a/src/uk/ac/open/lts/webmaths/StatusServlet.java
+++ b/src/uk/ac/open/lts/webmaths/StatusServlet.java
@@ -142,6 +142,10 @@ public class StatusServlet extends HttpServlet
 				{
 					out.append("<div class='error'>Rendering failed</div>");
 				}
+				catch(IOException ex)
+				{
+					out.append("<div class='error'>Rendering failed</div>");
+				}
 				out.append("</div>");
 				out.append("<div class='equation'>" + esc(details.getEquation().getContent()) + "</div>");
 				out.append("</li>");

--- a/src/uk/ac/open/lts/webmaths/mathjax/MathJax.java
+++ b/src/uk/ac/open/lts/webmaths/mathjax/MathJax.java
@@ -245,7 +245,7 @@ public class MathJax
 	private final static Pattern REGEX_BASELINE_PIXELS = Pattern.compile(
 		"^<svg[^>]* style=\"vertical-align: ((-?[0-9]+(?:\\.[0-9]+)?)px)");
 	private final static Pattern REGEX_WIDTH = Pattern.compile(
-		"^<svg[^>]* width=\"(([0-9]+(?:\\.[0-9]+)?)ex)\"");
+		"^<svg[^>]* width=\"(([0-9]+(?:\\.[0-9]+)?)(ex)?)\"");
 	private final static Pattern REGEX_HEIGHT = Pattern.compile(
 		"^<svg[^>]* height=\"(([0-9]+(?:\\.[0-9]+)?)ex)\"");
 	private final static Pattern REGEX_VIEWBOX = Pattern.compile(


### PR DESCRIPTION
Bugs found in acct . The width for empty equations  is 0 without 'ex' and was throwing exceptions.